### PR TITLE
Patch nilearn link

### DIFF
--- a/tutorials.html
+++ b/tutorials.html
@@ -229,7 +229,7 @@
                                       <ul>
                                         <li> <a href="https://pandas.pydata.org/">MNE</a>: MEG and EEG analysis and visualization in python.</li>
                                         <li> <a href="https://github.com/neuropoly/qMRLab">qMRLab</a>: open-source Matlab software for quantitative MR image analysis.</li>
-                                        <li> <a> href="https://nilearn.github.io/"> nilearn </a> machine learning for neuroimaging, in python.</li>
+                                        <li> <a href="https://nilearn.github.io/"> nilearn </a> machine learning for neuroimaging, in python.</li>
                                         <li> fMRI preprocessing and feature extraction. </li>
                                         <li> M/EEG preprocessing and feature extraction. </li>
                                         <li> structural MRI preprocessing and feature extraction. </li>                                        


### PR DESCRIPTION
Nilearn neuroimaging tutorial currently appears as:
> href="https://nilearn.github.io/"> nilearn machine learning for neuroimaging, in python.

Patch for proper rendering !